### PR TITLE
Fix hexToHsl check

### DIFF
--- a/src/color-helper.ts
+++ b/src/color-helper.ts
@@ -114,10 +114,6 @@ export const hexToHsl = (hex: string) => {
   let max = Math.max(r, g, b), min = Math.min(r, g, b);
   let h, s, l = (max + min) / 2;
 
-  if (!h) {
-    throw new Error("h is not a humber")
-  }
-
   if(max == min){
     h = s = 0; // achromatic
   } else {


### PR DESCRIPTION
## Summary
- fix incorrect `h` check in `hexToHsl`

## Testing
- `npm run build` *(fails: Cannot find module '@network-utils/arp-lookup' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_683ffaf5db608321bfcd28e6485b2875