### PR TITLE
Improve color helper validation

### DIFF
--- a/src/color-helper.ts
+++ b/src/color-helper.ts
@@ -98,11 +98,14 @@ export const presetColors = {
 
 
 export const hexToHsl = (hex: string) => {
-  if (hex.toLowerCase() === '#000000') return console.error('Cannot set light to black');
-  let result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  if (hex.toLowerCase() === '#000000') {
+    throw new Error('Cannot set light to black');
+  }
+
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
 
   if (!result) {
-    throw new Error("result is empty")
+    throw new Error('Invalid hex string');
   }
 
   let r = parseInt(result[1], 16);
@@ -143,7 +146,9 @@ export const hexToHsl = (hex: string) => {
 export const temperature = (temp: string) => {
   let t = parseInt(temp.slice(0,-1));
 
-  if(t<2500||t>6500) return console.error('Colour temperature should be between 2500K and 6500K.');
+  if(t < 2500 || t > 6500) {
+    throw new Error('Colour temperature should be between 2500K and 6500K.');
+  }
 
   return{
     color_temp: t

--- a/test/color-helper.test.js
+++ b/test/color-helper.test.js
@@ -1,0 +1,32 @@
+const assert = require('assert');
+const path = require('path');
+
+// Attempt to import the TypeScript source using ts-node if available
+let colorHelper;
+try {
+  require('ts-node/register');
+  colorHelper = require('../src/color-helper');
+} catch (err) {
+  console.error('ts-node is required to run tests');
+  process.exitCode = 1;
+  return;
+}
+
+function expectThrows(fn, message) {
+  let threw = false;
+  try {
+    fn();
+  } catch (e) {
+    threw = true;
+    assert.strictEqual(e.message, message);
+  }
+  if (!threw) {
+    throw new Error('Expected function to throw');
+  }
+}
+
+expectThrows(() => colorHelper.hexToHsl('#000000'), 'Cannot set light to black');
+expectThrows(() => colorHelper.hexToHsl('#zzzzzz'), 'Invalid hex string');
+expectThrows(() => colorHelper.temperature('2000K'), 'Colour temperature should be between 2500K and 6500K.');
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- throw errors on black/invalid hex in `hexToHsl`
- throw error when temperature is out of range
- add a small test file demonstrating error conditions

## Testing
- `node test/color-helper.test.js` *(fails: ts-node is required)*

------
https://chatgpt.com/codex/tasks/task_e_683ffc6170448321ba56cb008b5ba2c7