### PR TITLE
Clarify loginDevice network note

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ async function run() {
 run().catch(console.error);
 ```
 
+> **Note**: `loginDevice` resolves the device's IP address via your local network.
+> Ensure the machine running this code is connected to the same network as the
+> Tapo device. If you already know the IP address or ARP discovery fails, call
+> `loginDeviceByIp(email, password, deviceIp)` instead.
+
 ---
 
 ## 💡 Features


### PR DESCRIPTION
## Summary
- explain that loginDevice only works if the device is on the same LAN
- mention loginDeviceByIp as fallback

## Testing
- `npm run build` *(fails: Cannot find module)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683ffc5de59083219122f33fd54e0efa