### PR TITLE
Add basic tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ or if using from local project:
 npm install
 ```
 
+## 🧪 Running Tests
+
+After installing dependencies you can execute the test suite with:
+
+```bash
+npm test
+```
+
 ---
 
 ## 🚀 Quickstart Example

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
         "build": "tsc",
         "start": "node dist/index.js",
         "demo": "npx tsc examples/demo.ts && node examples/demo.js",
-        "dev": "ts-node examples/demo.ts"
+        "dev": "ts-node examples/demo.ts",
+        "test": "ts-node tests/index.ts"
     },
     "files": ["dist"],
     "keywords": [

--- a/tests/color-helper.test.ts
+++ b/tests/color-helper.test.ts
@@ -1,0 +1,22 @@
+import assert from 'assert';
+import { hexToHsl, getColour } from '../src/color-helper';
+
+export function test_hexToHsl() {
+  const expected = { hue: 0, saturation: 100, brightness: 50 };
+  assert.deepStrictEqual(hexToHsl('#ff0000'), expected);
+}
+
+export function test_getColour_preset() {
+  const expected = { hue: 0, saturation: 100, color_temp: 0 };
+  assert.deepStrictEqual(getColour('red'), expected);
+}
+
+export function test_getColour_hex() {
+  const expected = { hue: 120, saturation: 100, brightness: 50 };
+  assert.deepStrictEqual(getColour('#00ff00'), expected);
+}
+
+export function test_getColour_temp() {
+  const expected = { color_temp: 3000 };
+  assert.deepStrictEqual(getColour('3000K'), expected);
+}

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,0 +1,17 @@
+import { test_hexToHsl, test_getColour_preset, test_getColour_hex, test_getColour_temp } from './color-helper.test';
+
+function run(name: string, fn: () => void) {
+  try {
+    fn();
+    console.log(`✓ ${name}`);
+  } catch (err) {
+    console.error(`✗ ${name}`);
+    console.error(err);
+    process.exitCode = 1;
+  }
+}
+
+run('hexToHsl converts to HSL', test_hexToHsl);
+run('getColour returns preset color values', test_getColour_preset);
+run('getColour handles hex strings', test_getColour_hex);
+run('getColour handles colour temperature', test_getColour_temp);


### PR DESCRIPTION
## Summary
- add a tiny TS test runner and color-helper tests
- expose `npm test` in package.json
- document how to run the new tests

## Testing
- `npm test` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffc5f49608321b8622961bfea3cb6