### PR TITLE
Add RGB support and extend color helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ run().catch(console.error);
 
 - Cloud login
 - List devices from TP-Link Cloud
-- Set color by name, hex, temperature, HSL
+- Set color by name, hex, temperature, HSL or RGB
 - A lot of color presets included
 - Full TypeScript strict typing
 - Easy to use
@@ -87,7 +87,7 @@ run().catch(console.error);
 
 ## 🌈 Available Color Presets
 
-`blue`, `red`, `yellow`, `green`, `cyan`, `magenta`, `orange`, `pink`, `turquoise`, `violet`, `lavender`, `coral`, `mint`, `white`, `daylightwhite`, `warmwhite`
+`blue`, `red`, `yellow`, `green`, `cyan`, `magenta`, `orange`, `pink`, `turquoise`, `violet`, `lavender`, `coral`, `mint`, `teal`, `navy`, `olive`, `maroon`, `grey`, `white`, `daylightwhite`, `warmwhite`
 
 (And you can set any hex color like `#ff0000` too!)
 

--- a/src/color-helper.ts
+++ b/src/color-helper.ts
@@ -70,6 +70,47 @@ export const presetColors = {
     color_temp: 0
   },
 
+  lavender: {
+    hue: 250,
+    saturation: 100,
+    color_temp: 0
+  },
+  coral: {
+    hue: 16,
+    saturation: 100,
+    color_temp: 0
+  },
+  mint: {
+    hue: 150,
+    saturation: 100,
+    color_temp: 0
+  },
+  teal: {
+    hue: 180,
+    saturation: 100,
+    color_temp: 0
+  },
+  navy: {
+    hue: 240,
+    saturation: 100,
+    color_temp: 0
+  },
+  olive: {
+    hue: 60,
+    saturation: 100,
+    color_temp: 0
+  },
+  maroon: {
+    hue: 0,
+    saturation: 100,
+    color_temp: 0
+  },
+  grey: {
+    hue: 0,
+    saturation: 0,
+    color_temp: 0
+  },
+
   white: {
     color_temp: 4500
   },
@@ -115,7 +156,9 @@ export const hexToHsl = (hex: string) => {
   r /= 255, g /= 255, b /= 255;
 
   let max = Math.max(r, g, b), min = Math.min(r, g, b);
-  let h, s, l = (max + min) / 2;
+  let h = 0;
+  let s = 0;
+  let l = (max + min) / 2;
 
   if(max == min){
     h = s = 0; // achromatic
@@ -153,12 +196,57 @@ export const temperature = (temp: string) => {
   return{
     color_temp: t
   };
-}
+};
 
-export const getColour = (colour: string) => {
-  colour = colour.toLowerCase();
-  if (colour.startsWith('#')) return hexToHsl(colour);
-  if (colour.endsWith('k')) return temperature(colour);
-  if (Object.keys(presetColors).includes(colour)) return presetColors[colour as keyof typeof presetColors];
-  throw new Error('Invalid Colour');
-}
+export type RGB = { r: number; g: number; b: number };
+
+export const rgbToHsl = (rgb: RGB) => {
+  const { r, g, b } = rgb;
+  if (r === 0 && g === 0 && b === 0) {
+    throw new Error('Cannot set light to black');
+  }
+
+  let rNorm = r / 255;
+  let gNorm = g / 255;
+  let bNorm = b / 255;
+
+  let max = Math.max(rNorm, gNorm, bNorm), min = Math.min(rNorm, gNorm, bNorm);
+  let h = 0;
+  let s = 0;
+  let l: number = (max + min) / 2;
+
+  if (max == min) {
+    h = s = 0;
+  } else {
+    let d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case rNorm: h = (gNorm - bNorm) / d + (gNorm < bNorm ? 6 : 0); break;
+      case gNorm: h = (bNorm - rNorm) / d + 2; break;
+      default: h = (rNorm - gNorm) / d + 4; break;
+    }
+    h /= 6;
+  }
+
+  s = Math.round(s * 100);
+  l = Math.round(l * 100);
+  h = Math.round(360 * h);
+
+  return {
+    hue: h,
+    saturation: s,
+    brightness: l
+  };
+};
+
+export const getColor = (colour: string | RGB) => {
+  if (typeof colour === 'string') {
+    let c = colour.toLowerCase();
+    if (c.startsWith('#')) return hexToHsl(c);
+    if (c.endsWith('k')) return temperature(c);
+    if (Object.keys(presetColors).includes(c)) return presetColors[c as keyof typeof presetColors];
+    throw new Error('Invalid Colour');
+  }
+  return rgbToHsl(colour);
+};
+

--- a/src/tapo-device.ts
+++ b/src/tapo-device.ts
@@ -1,4 +1,4 @@
-import { getColour } from "./color-helper"
+import { getColor, RGB } from "./color-helper"
 import { base64Decode } from "./tplink-cipher"
 import { TapoDeviceInfo, TapoProtocol } from "./types"
 
@@ -57,8 +57,8 @@ export const TapoDevice = ({ send }: TapoProtocol) => {
         await send(setHueRequest)
       },
       
-      setColour: async (colour: string = 'white') => {
-        const params = getColour(colour);
+      setColour: async (colour: string | RGB = 'white') => {
+        const params = getColor(colour);
       
         const setColourRequest = {
           "method": "set_device_info",

--- a/test/color-helper.test.js
+++ b/test/color-helper.test.js
@@ -29,4 +29,42 @@ expectThrows(() => colorHelper.hexToHsl('#000000'), 'Cannot set light to black')
 expectThrows(() => colorHelper.hexToHsl('#zzzzzz'), 'Invalid hex string');
 expectThrows(() => colorHelper.temperature('2000K'), 'Colour temperature should be between 2500K and 6500K.');
 
+assert.deepStrictEqual(
+  colorHelper.hexToHsl('#ff0000'),
+  { hue: 0, saturation: 100, brightness: 50 }
+);
+
+assert.deepStrictEqual(
+  colorHelper.rgbToHsl({ r: 255, g: 0, b: 0 }),
+  { hue: 0, saturation: 100, brightness: 50 }
+);
+
+assert.deepStrictEqual(
+  colorHelper.getColor('#ff0000'),
+  { hue: 0, saturation: 100, brightness: 50 }
+);
+
+assert.deepStrictEqual(
+  colorHelper.getColor({ r: 255, g: 0, b: 0 }),
+  { hue: 0, saturation: 100, brightness: 50 }
+);
+
+assert.deepStrictEqual(
+  colorHelper.getColor('red'),
+  { hue: 0, saturation: 100, color_temp: 0 }
+);
+
+assert.deepStrictEqual(
+  colorHelper.getColor('mint'),
+  { hue: 150, saturation: 100, color_temp: 0 }
+);
+
+assert.deepStrictEqual(
+  colorHelper.getColor('4500K'),
+  { color_temp: 4500 }
+);
+
+expectThrows(() => colorHelper.getColor('invalid'), 'Invalid Colour');
+expectThrows(() => colorHelper.getColor({ r: 0, g: 0, b: 0 }), 'Cannot set light to black');
+
 console.log('All tests passed');


### PR DESCRIPTION
## Summary
- rename `getColour` to `getColor`
- allow passing RGB objects to `getColor`
- add new preset colours
- update TapoDevice to use `getColor`
- enhance README with RGB info and more colours
- expand color-helper tests

## Testing
- `npm test` *(fails: ts-node not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6847faa45ca48321859d8cc92adea7cf