### PR TITLE
Update README with hex/RGB usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ async function run() {
   await device.setColour('orange');
   await TPLink.API.delay(500);
 
+  // colours can also be set using hex codes
+  await device.setColour('#00ff00');
+  await TPLink.API.delay(500);
+
+  // or by providing an RGB object
+  await device.setColour({ r: 0, g: 0, b: 255 });
+  await TPLink.API.delay(500);
+
+  // you can change only the brightness (or hue/saturation)
+  await device.setBrightness(50);
+  await TPLink.API.delay(500);
+
   //...
 }
 


### PR DESCRIPTION
## Summary
- show how to set colours using hex and RGB
- add brightness example in quickstart

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847fe68a4a08321b856eb598caf165c