### PR TITLE
Add extensive tests and manual example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+TAPO_USERNAME=your-email@example.com
+TAPO_PASSWORD=your-password
+TAPO_DEVICE_ID=your-device-id

--- a/examples/manual.ts
+++ b/examples/manual.ts
@@ -1,0 +1,32 @@
+import { config } from 'dotenv';
+import * as TPLink from '../src';
+
+config();
+
+const email = process.env.TAPO_USERNAME;
+const password = process.env.TAPO_PASSWORD;
+const deviceId = process.env.TAPO_DEVICE_ID;
+
+if (!email || !password || !deviceId) {
+  console.error('Please set TAPO_USERNAME, TAPO_PASSWORD and TAPO_DEVICE_ID in .env');
+  process.exit(1);
+}
+
+async function run() {
+  const cloud = await TPLink.API.cloudLogin(email, password);
+  const devices = await cloud.listDevices();
+  const target = devices.find(d => d.deviceId === deviceId);
+  if (!target) {
+    throw new Error('Device not found');
+  }
+  const device = await TPLink.API.loginDevice(email, password, target);
+  const info = await device.getDeviceInfo();
+  console.log('Device Info:', info);
+  await device.turnOn();
+  console.log('Turned on');
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "start": "node dist/index.js",
         "demo": "npx tsc examples/demo.ts && node examples/demo.js",
         "dev": "ts-node examples/demo.ts",
+        "manual": "ts-node examples/manual.ts",
         "test": "jest",
         "coverage": "jest --coverage",
         "publish": "tsc && npm publish"
@@ -39,6 +40,7 @@
         "ts-jest": "^29.1.0",
         "ts-node": "^10.9.1",
         "tslint": "^6.1.3",
-        "typescript": "^5.3.0"
+        "typescript": "^5.3.0",
+        "dotenv": "^16.3.1"
     }
 }

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,0 +1,19 @@
+import { config } from 'dotenv';
+import * as TPLink from '../src';
+
+config();
+
+const email = process.env.TAPO_USERNAME;
+const password = process.env.TAPO_PASSWORD;
+const deviceId = process.env.TAPO_DEVICE_ID;
+
+const run = email && password && deviceId;
+(run ? test : test.skip)('login and fetch device info', async () => {
+  const cloud = await TPLink.API.cloudLogin(email, password);
+  const devices = await cloud.listDevices();
+  const target = devices.find(d => d.deviceId === deviceId);
+  expect(target).toBeDefined();
+  const device = await TPLink.API.loginDevice(email, password, target!);
+  const info = await device.getDeviceInfo();
+  expect(info.device_id).toBe(deviceId);
+});

--- a/test/network-tools.test.ts
+++ b/test/network-tools.test.ts
@@ -1,0 +1,33 @@
+import { resolveMacToIp } from '../src/network-tools';
+
+jest.mock('@network-utils/arp-lookup', () => ({
+  toIP: jest.fn(),
+}));
+
+jest.mock('local-devices', () => jest.fn());
+
+const arp = require('@network-utils/arp-lookup');
+const find = require('local-devices');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('resolveMacToIp', () => {
+  test('returns ip from arp lookup', async () => {
+    (arp.toIP as jest.Mock).mockResolvedValue('192.168.0.10');
+    const ip = await resolveMacToIp('84:d8:1b:aa:bb:cc');
+    expect(ip).toBe('192.168.0.10');
+    expect(find).not.toHaveBeenCalled();
+  });
+
+  test('falls back to local-devices when arp fails', async () => {
+    (arp.toIP as jest.Mock).mockResolvedValueOnce(undefined).mockResolvedValueOnce('192.168.0.11');
+    (find as jest.Mock).mockResolvedValue([{ mac: '84:d8:1b:aa:bb:cc', ip: '192.168.0.11' }]);
+
+    const ip = await resolveMacToIp('84-d8-1b-aa-bb-cc');
+    expect(ip).toBe('192.168.0.11');
+    expect(arp.toIP).toHaveBeenCalledTimes(2);
+    expect(find).toHaveBeenCalled();
+  });
+});

--- a/test/tapo-device.test.ts
+++ b/test/tapo-device.test.ts
@@ -1,0 +1,55 @@
+import { TapoDevice } from '../src/tapo-device';
+import { presetColors } from '../src/color-helper';
+
+describe('TapoDevice', () => {
+  test('device control methods send correct payloads', async () => {
+    const send = jest.fn(async (req) => req);
+    const device = TapoDevice({ send });
+
+    await device.turnOn();
+    expect(send).toHaveBeenCalledWith({ method: 'set_device_info', params: { device_on: true } });
+
+    await device.turnOff();
+    expect(send).toHaveBeenCalledWith({ method: 'set_device_info', params: { device_on: false } });
+
+    await device.setBrightness(50);
+    expect(send).toHaveBeenCalledWith({ method: 'set_device_info', params: { brightness: 50 } });
+
+    await device.setSaturation(20);
+    expect(send).toHaveBeenCalledWith({ method: 'set_device_info', params: { saturation: 20 } });
+
+    await device.setHue(10);
+    expect(send).toHaveBeenCalledWith({ method: 'set_device_info', params: { hue: 10 } });
+
+    await device.setColour('red');
+    expect(send).toHaveBeenCalledWith({ method: 'set_device_info', params: presetColors.red });
+
+    await device.setHSL(370, -10, 110);
+    expect(send).toHaveBeenCalledWith({ method: 'set_device_info', params: { hue: 10, saturation: 0, brightness: 100 } });
+  });
+
+  test('setHSL turns off device when luminosity is zero', async () => {
+    const send = jest.fn(async (req) => req);
+    const device = TapoDevice({ send });
+
+    await device.setHSL(0, 50, 0);
+    expect(send).toHaveBeenNthCalledWith(1, { method: 'set_device_info', params: { device_on: false } });
+    expect(send).toHaveBeenNthCalledWith(2, { method: 'set_device_info', params: { hue: 0, saturation: 50, brightness: 0 } });
+  });
+
+  test('getDeviceInfo decodes base64 fields', async () => {
+    const info = { nickname: Buffer.from('bulb').toString('base64'), ssid: Buffer.from('wifi').toString('base64') };
+    const send = jest.fn(async () => info);
+    const device = TapoDevice({ send });
+    const result = await device.getDeviceInfo();
+    expect(result.nickname).toBe('bulb');
+    expect(result.ssid).toBe('wifi');
+  });
+
+  test('getEnergyUsage sends correct request', async () => {
+    const send = jest.fn(async () => ({}));
+    const device = TapoDevice({ send });
+    await device.getEnergyUsage();
+    expect(send).toHaveBeenCalledWith({ method: 'get_energy_usage' });
+  });
+});

--- a/test/tapo-utils.test.ts
+++ b/test/tapo-utils.test.ts
@@ -1,0 +1,60 @@
+import { augmentTapoDevice, isTapoDevice, checkError } from '../src/tapo-utils';
+import { base64Encode } from '../src/tplink-cipher';
+
+describe('tapo-utils', () => {
+  test('augmentTapoDevice decodes alias for Tapo devices', async () => {
+    const alias = base64Encode('lamp');
+    const device: any = { deviceType: 'SMART.TAPOBULB', alias };
+    const result = await augmentTapoDevice(device);
+    expect(result.alias).toBe('lamp');
+  });
+
+  test('augmentTapoDevice returns original for non Tapo devices', async () => {
+    const device: any = { deviceType: 'OTHER.DEVICE', alias: 'abc' };
+    const result = await augmentTapoDevice(device);
+    expect(result).toEqual(device);
+  });
+
+  test('isTapoDevice detects device types', () => {
+    expect(isTapoDevice('SMART.TAPOPLUG')).toBe(true);
+    expect(isTapoDevice('SMART.TAPOBULB')).toBe(true);
+    expect(isTapoDevice('SMART.IPCAMERA')).toBe(true);
+    expect(isTapoDevice('OTHER')).toBe(false);
+  });
+
+  const codeMap: Record<number, string> = {
+    -1005: 'AES Decode Fail',
+    -1006: 'Request length error',
+    -1008: 'Invalid request params',
+    -1301: 'Rate limit exceeded',
+    -1101: 'Session params error',
+    -1010: 'Invalid public key length',
+    -1012: 'Invalid terminal UUID',
+    -1501: 'Invalid credentials',
+    -1002: 'Transport not available error',
+    -1003: 'Malformed json request',
+    -20004: 'API rate limit exceeded',
+    -20104: 'Missing credentials',
+    -20601: 'Incorrect email or password',
+    -20675: 'Cloud token expired or invalid',
+    1000: 'Null transport error',
+    1001: 'Command cancel error',
+    1002: 'Transport not available error',
+    1003: 'Device supports KLAP protocol - Legacy login not supported',
+    1100: 'Handshake failed',
+    1111: 'Login failed',
+    1112: 'Http transport error',
+    1200: 'Multirequest failed',
+    9999: 'Session Timeout',
+  };
+
+  test('checkError throws correct messages', () => {
+    for (const [code, msg] of Object.entries(codeMap)) {
+      expect(() => checkError({ error_code: Number(code) })).toThrow(msg);
+    }
+  });
+
+  test('checkError does nothing on success', () => {
+    expect(checkError({ error_code: 0 })).toBeUndefined();
+  });
+});

--- a/test/tplink-cipher.test.ts
+++ b/test/tplink-cipher.test.ts
@@ -1,0 +1,27 @@
+import { encrypt, decrypt, base64Encode, base64Decode, shaDigest } from '../src/tplink-cipher';
+import crypto from 'crypto';
+
+describe('tplink-cipher', () => {
+  test('base64 encode/decode roundtrip', () => {
+    const txt = 'hello';
+    const encoded = base64Encode(txt);
+    expect(encoded).toBe(Buffer.from(txt).toString('base64'));
+    expect(base64Decode(encoded)).toBe(txt);
+  });
+
+  test('shaDigest returns sha1 hash', () => {
+    const val = 'abc';
+    const expected = crypto.createHash('sha1').update(val).digest('hex');
+    expect(shaDigest(val)).toBe(expected);
+  });
+
+  test('encrypt/decrypt round trip', () => {
+    const key = crypto.randomBytes(16);
+    const iv = crypto.randomBytes(16);
+    const deviceKey = { key, iv, deviceIp: '', sessionCookie: '' } as any;
+    const data = { a: 1, b: 'test' };
+    const enc = encrypt(data, deviceKey);
+    const dec = decrypt(enc, deviceKey);
+    expect(dec).toEqual(data);
+  });
+});


### PR DESCRIPTION
## Summary
- add environment sample for integration tests
- create manual control script using the same .env
- add unit tests for tapo-device, tapo-utils, network tools and cipher helpers
- add integration test that runs when credentials are present
- expose `manual` script and dotenv dev dependency

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6849751ef5c88321927fb3f8a4a8e38c