### PR TITLE
Add GitHub Actions workflow for npm tests

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -1,0 +1,18 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - run: npm install
+      - run: npm test


### PR DESCRIPTION
## Summary
- run `npm test` automatically on pushes to `main`

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm install` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_684a8a1b427c8321a383be91df60fa78