### PR TITLE
Fix duplicate export in TapoDevice

### DIFF
--- a/src/tapo-device.ts
+++ b/src/tapo-device.ts
@@ -94,4 +94,3 @@ export const TapoDevice = ({ send }: TapoProtocol): TapoDeviceController => {
   return new TapoDeviceController({ send });
 };
 
-export { TapoDeviceController };


### PR DESCRIPTION
## Summary
- remove redundant export of `TapoDeviceController` to avoid TS2323

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a8dc27d448321afd3f30a23d560a5