### PR TITLE
Add HSL, HSV, CMYK support to color helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ run().catch(console.error);
 
 - Cloud login
 - List devices from TP-Link Cloud
-- Set color by name, hex, temperature, HSL or RGB
+- Set color by name, hex, temperature and now also by HSL, HSV, CMYK or RGB
 - A lot of color presets included
 - Full TypeScript strict typing
 - Easy to use

--- a/src/color-helper.ts
+++ b/src/color-helper.ts
@@ -199,6 +199,9 @@ export const temperature = (temp: string) => {
 };
 
 export type RGB = { r: number; g: number; b: number };
+export type HSL = { h: number; s: number; l: number };
+export type HSV = { h: number; s: number; v: number };
+export type CMYK = { c: number; m: number; y: number; k: number };
 
 export const rgbToHsl = (rgb: RGB) => {
   const { r, g, b } = rgb;
@@ -239,14 +242,116 @@ export const rgbToHsl = (rgb: RGB) => {
   };
 };
 
-export const getColor = (colour: string | RGB) => {
+export const hslToHsl = (hsl: HSL) => {
+  const { h, s, l } = hsl;
+  if (l === 0) {
+    throw new Error('Cannot set light to black');
+  }
+  const hue = Math.round(h % 360);
+  const saturation = Math.max(0, Math.min(100, s));
+  const brightness = Math.max(0, Math.min(100, l));
+  return { hue, saturation, brightness };
+};
+
+const hsvToRgb = (hsv: HSV): RGB => {
+  const h = hsv.h % 360;
+  const s = Math.max(0, Math.min(100, hsv.s)) / 100;
+  const v = Math.max(0, Math.min(100, hsv.v)) / 100;
+
+  const c = v * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = v - c;
+
+  let r = 0, g = 0, b = 0;
+
+  if (h >= 0 && h < 60) {
+    r = c; g = x; b = 0;
+  } else if (h >= 60 && h < 120) {
+    r = x; g = c; b = 0;
+  } else if (h >= 120 && h < 180) {
+    r = 0; g = c; b = x;
+  } else if (h >= 180 && h < 240) {
+    r = 0; g = x; b = c;
+  } else if (h >= 240 && h < 300) {
+    r = x; g = 0; b = c;
+  } else {
+    r = c; g = 0; b = x;
+  }
+
+  return {
+    r: Math.round((r + m) * 255),
+    g: Math.round((g + m) * 255),
+    b: Math.round((b + m) * 255)
+  };
+};
+
+const cmykToRgb = (cmyk: CMYK): RGB => {
+  const c = Math.max(0, Math.min(100, cmyk.c)) / 100;
+  const m = Math.max(0, Math.min(100, cmyk.m)) / 100;
+  const y = Math.max(0, Math.min(100, cmyk.y)) / 100;
+  const k = Math.max(0, Math.min(100, cmyk.k)) / 100;
+
+  return {
+    r: Math.round(255 * (1 - c) * (1 - k)),
+    g: Math.round(255 * (1 - m) * (1 - k)),
+    b: Math.round(255 * (1 - y) * (1 - k))
+  };
+};
+
+export const hsvToHsl = (hsv: HSV) => {
+  if (hsv.v === 0) {
+    throw new Error('Cannot set light to black');
+  }
+  return rgbToHsl(hsvToRgb(hsv));
+};
+
+export const cmykToHsl = (cmyk: CMYK) => {
+  if (cmyk.k === 100) {
+    throw new Error('Cannot set light to black');
+  }
+  return rgbToHsl(cmykToRgb(cmyk));
+};
+
+const mixPresetColors = (name: string) => {
+  for (const first of Object.keys(presetColors)) {
+    for (const second of Object.keys(presetColors)) {
+      if (first + second === name) {
+        const c1 = presetColors[first as keyof typeof presetColors];
+        const c2 = presetColors[second as keyof typeof presetColors];
+
+        if ('color_temp' in c1 && !('hue' in c1) && 'color_temp' in c2 && !('hue' in c2)) {
+          return { color_temp: Math.round((c1.color_temp + c2.color_temp) / 2) };
+        }
+
+        if ('hue' in c1 && 'hue' in c2) {
+          return {
+            hue: Math.round(((c1 as any).hue + (c2 as any).hue) / 2),
+            saturation: Math.round(((c1 as any).saturation + (c2 as any).saturation) / 2),
+            color_temp: 0,
+          };
+        }
+      }
+    }
+  }
+  return undefined;
+};
+
+export const getColor = (colour: string | RGB | HSL | HSV | CMYK) => {
   if (typeof colour === 'string') {
-    let c = colour.toLowerCase();
+    const c = colour.toLowerCase();
     if (c.startsWith('#')) return hexToHsl(c);
     if (c.endsWith('k')) return temperature(c);
     if (Object.keys(presetColors).includes(c)) return presetColors[c as keyof typeof presetColors];
+    const mixed = mixPresetColors(c);
+    if (mixed) return mixed;
     throw new Error('Invalid Colour');
   }
-  return rgbToHsl(colour);
+
+  if ('r' in colour && 'g' in colour && 'b' in colour) return rgbToHsl(colour as RGB);
+  if ('h' in colour && 's' in colour && 'l' in colour) return hslToHsl(colour as HSL);
+  if ('h' in colour && 's' in colour && 'v' in colour) return hsvToHsl(colour as HSV);
+  if ('c' in colour && 'm' in colour && 'y' in colour && 'k' in colour) return cmykToHsl(colour as CMYK);
+
+  throw new Error('Invalid Colour');
 };
 

--- a/test/color-helper.test.ts
+++ b/test/color-helper.test.ts
@@ -1,4 +1,4 @@
-import { hexToHsl, rgbToHsl, getColor, temperature } from '../src/color-helper';
+import { hexToHsl, rgbToHsl, getColor, temperature, hsvToHsl, hslToHsl, cmykToHsl, presetColors } from '../src/color-helper';
 
 describe('color-helper', () => {
   test('throws on invalid input', () => {
@@ -19,5 +19,24 @@ describe('color-helper', () => {
     expect(getColor('red')).toEqual({ hue: 0, saturation: 100, color_temp: 0 });
     expect(getColor('mint')).toEqual({ hue: 150, saturation: 100, color_temp: 0 });
     expect(getColor('4500K')).toEqual({ color_temp: 4500 });
+  });
+
+  test('handles additional colour models', () => {
+    const redHsl = { hue: 0, saturation: 100, brightness: 50 };
+    expect(hslToHsl({ h: 0, s: 100, l: 50 })).toEqual(redHsl);
+    expect(hsvToHsl({ h: 0, s: 100, v: 100 })).toEqual({ hue: 0, saturation: 100, brightness: 100 });
+    expect(cmykToHsl({ c: 0, m: 100, y: 100, k: 0 })).toEqual(redHsl);
+    expect(getColor({ h: 0, s: 100, l: 50 })).toEqual(redHsl);
+    expect(getColor({ h: 0, s: 100, v: 100 })).toEqual({ hue: 0, saturation: 100, brightness: 100 });
+    expect(getColor({ c: 0, m: 100, y: 100, k: 0 })).toEqual(redHsl);
+  });
+
+  test('mixes preset colours', () => {
+    const mixed = getColor('bluegreen');
+    expect(mixed).toEqual({
+      hue: Math.round((presetColors.blue.hue + presetColors.green.hue) / 2),
+      saturation: Math.round((presetColors.blue.saturation + presetColors.green.saturation) / 2),
+      color_temp: 0,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- support HSL/HSV/CMYK input types in color-helper
- implement conversions from these colour models
- allow mixing two preset colours by concatenating their names
- update tests for new features
- document new colour model support in README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684a90e91a70832187deb1822ff73dba