### PR TITLE
Fix HSV brightness conversion

### DIFF
--- a/src/color-helper.ts
+++ b/src/color-helper.ts
@@ -302,7 +302,10 @@ export const hsvToHsl = (hsv: HSV) => {
   if (hsv.v === 0) {
     throw new Error('Cannot set light to black');
   }
-  return rgbToHsl(hsvToRgb(hsv));
+  const hue = Math.round(hsv.h % 360);
+  const saturation = Math.max(0, Math.min(100, hsv.s));
+  const brightness = Math.max(0, Math.min(100, hsv.v));
+  return { hue, saturation, brightness };
 };
 
 export const cmykToHsl = (cmyk: CMYK) => {


### PR DESCRIPTION
## Summary
- preserve value component in `hsvToHsl` so brightness stays consistent

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68500e2757f88321a3d90aa2df2b4426